### PR TITLE
Fix/split into framework and executable

### DIFF
--- a/Sources/SwiftPolyglot/main.swift
+++ b/Sources/SwiftPolyglot/main.swift
@@ -1,6 +1,17 @@
+import Foundation
 import SwiftPolyglotCore
 
-let swiftPolyglot: SwiftPolyglot = .init(arguments: CommandLine.arguments)
+guard
+    let enumerator = FileManager.default.enumerator(atPath: FileManager.default.currentDirectoryPath),
+    let filePaths = enumerator.allObjects as? [String]
+else {
+    exit(EXIT_FAILURE)
+}
+
+let swiftPolyglot: SwiftPolyglot = .init(
+    arguments: Array(CommandLine.arguments.dropFirst()),
+    filePaths: filePaths
+)
 
 do {
     try swiftPolyglot.run()

--- a/Sources/SwiftPolyglotCore/SwiftPolyglot.swift
+++ b/Sources/SwiftPolyglotCore/SwiftPolyglot.swift
@@ -8,14 +8,14 @@ public struct SwiftPolyglot {
     }
 
     public func run() throws {
-        guard CommandLine.arguments.count > 1 else {
+        guard !arguments.isEmpty else {
             print("Usage: script.swift <language codes> [--errorOnMissing]")
             exit(1)
         }
 
         let isRunningFromGitHubActions = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
-        let languages = CommandLine.arguments[1].split(separator: ",").map(String.init)
-        let errorOnMissing = CommandLine.arguments.contains("--errorOnMissing")
+        let languages = arguments[0].split(separator: ",").map(String.init)
+        let errorOnMissing = arguments.contains("--errorOnMissing")
 
         let fileManager = FileManager.default
         let currentDirectoryPath = fileManager.currentDirectoryPath

--- a/Sources/SwiftPolyglotCore/SwiftPolyglot.swift
+++ b/Sources/SwiftPolyglotCore/SwiftPolyglot.swift
@@ -2,9 +2,11 @@ import Foundation
 
 public struct SwiftPolyglot {
     private let arguments: [String]
+    private let filePaths: [String]
 
-    public init(arguments: [String]) {
+    public init(arguments: [String], filePaths: [String]) {
         self.arguments = arguments
+        self.filePaths = filePaths
     }
 
     public func run() throws {
@@ -16,9 +18,6 @@ public struct SwiftPolyglot {
         let isRunningFromGitHubActions = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true"
         let languages = arguments[0].split(separator: ",").map(String.init)
         let errorOnMissing = arguments.contains("--errorOnMissing")
-
-        let fileManager = FileManager.default
-        let currentDirectoryPath = fileManager.currentDirectoryPath
 
         var missingTranslations = false
 
@@ -56,13 +55,11 @@ public struct SwiftPolyglot {
             }
         }
 
-        func searchDirectory(_ dirPath: String) {
-            if let enumerator = fileManager.enumerator(atPath: dirPath) {
-                for case let file as String in enumerator {
-                    if file.hasSuffix(".xcstrings") {
-                        let fileURL = URL(fileURLWithPath: dirPath).appendingPathComponent(file)
-                        checkTranslations(in: fileURL, for: languages)
-                    }
+        func searchDirectory() {
+            for filePath in filePaths {
+                if filePath.hasSuffix(".xcstrings") {
+                    let fileURL = URL(fileURLWithPath: filePath)
+                    checkTranslations(in: fileURL, for: languages)
                 }
             }
         }
@@ -79,7 +76,7 @@ public struct SwiftPolyglot {
             }
         }
 
-        searchDirectory(currentDirectoryPath)
+        searchDirectory()
 
         if missingTranslations, errorOnMissing {
             print("Error: One or more translations are missing.")


### PR DESCRIPTION
Aloha!!

By moving the functionality to the framework, I forgot to implement the `arguments` property properly, and when playing with writing some tests, I realized that another property to pass the file paths would be needed. Here are the changes.

Cheers!!