### PR TITLE
Ignore strings where shouldTranslate is set to false

### DIFF
--- a/.swiftpm/configuration/Package.resolved
+++ b/.swiftpm/configuration/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/SwiftPolyglotCore/SwiftPolyglotCore.swift
+++ b/Sources/SwiftPolyglotCore/SwiftPolyglotCore.swift
@@ -88,6 +88,10 @@ public struct SwiftPolyglotCore {
         var missingTranslations: [MissingTranslation] = []
 
         for (originalString, translations) in strings {
+            if let shouldTranslate = translations["shouldTranslate"] as? Bool, shouldTranslate == false {
+                continue
+            }
+
             guard let localizations = translations["localizations"] as? [String: [String: Any]] else {
                 missingTranslations.append(
                     MissingTranslation(

--- a/Tests/SwiftPolyglotCoreTests/SwiftPolyglotCoreTests.swift
+++ b/Tests/SwiftPolyglotCoreTests/SwiftPolyglotCoreTests.swift
@@ -24,6 +24,28 @@ final class SwiftPolyglotCoreTests: XCTestCase {
         await XCTAssertNoThrowAsync(swiftPolyglotCore.run)
     }
 
+    func testStringCatalogWithDontTranslate() async throws {
+        guard
+            let stringCatalogFilePath = Bundle.module.path(
+                forResource: "WithDontTranslate",
+                ofType: ".xcstrings",
+                inDirectory: "TestFiles"
+            )
+        else {
+            XCTFail("Dont translate string catalog for testing not found")
+            return
+        }
+
+        let swiftPolyglotCore: SwiftPolyglotCore = .init(
+            filePaths: [stringCatalogFilePath],
+            languageCodes: ["de", "en"],
+            logsErrorOnMissingTranslation: true,
+            isRunningInAGitHubAction: false
+        )
+
+        await XCTAssertNoThrowAsync(swiftPolyglotCore.run)
+    }
+
     func testStringCatalogVariationsFullyTranslated() async throws {
         guard
             let stringCatalogFilePath = Bundle.module.path(

--- a/Tests/SwiftPolyglotCoreTests/TestFiles/WithDontTranslate.xcstrings
+++ b/Tests/SwiftPolyglotCoreTests/TestFiles/WithDontTranslate.xcstrings
@@ -1,0 +1,30 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "butterfly" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "butterfly"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "football" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "football"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
Xcode 16 introduces the ability to mark strings as "Don't Translate". SwiftPolyglot should respect that, and ignore strings where `shouldTranslate` is set to `false`